### PR TITLE
Fix README JSON code fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Create a `settings.json` file in the same folder as the executable:
   "enableExitOption": true,
   "enableManualShutdown": true
 }
+```


### PR DESCRIPTION
## Summary
- close the JSON code block in the README with a final set of backticks so the snippet renders properly

## Testing
- `python -m markdown README.md` *(fails: No module named markdown)*
- `pip install markdown` *(fails: Could not connect to proxy)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68965d7e99dc832b91046cd292baad09