### PR TITLE
Dispose resources on service form closing

### DIFF
--- a/PowerCommander/ServiceForm.cs
+++ b/PowerCommander/ServiceForm.cs
@@ -353,7 +353,29 @@ namespace PowerCommander
         /// </summary>
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            trayIcon.Visible = false;
+            // Ensure the tray icon is removed and disposed
+            if (trayIcon != null)
+            {
+                trayIcon.Visible = false;
+                trayIcon.Dispose();
+                trayIcon = null;
+            }
+
+            // Dispose active timers to release resources
+            if (countdownTimer != null)
+            {
+                countdownTimer.Stop();
+                countdownTimer.Dispose();
+                countdownTimer = null;
+            }
+
+            if (scheduleChecker != null)
+            {
+                scheduleChecker.Stop();
+                scheduleChecker.Dispose();
+                scheduleChecker = null;
+            }
+
             base.OnFormClosing(e);
         }
 


### PR DESCRIPTION
## Summary
- ensure tray icon and timers are disposed and nulled when ServiceForm closes

## Testing
- `dotnet build PowerCommander.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68966f9183bc832b9378db3d3c8ebbbe