### PR TITLE
Handle missing Run registry key and log access errors

### DIFF
--- a/PowerCommander/ServiceForm.cs
+++ b/PowerCommander/ServiceForm.cs
@@ -52,24 +52,53 @@ namespace PowerCommander
         #region Tray Icon Setup
         private void SetRunOnStartup(bool enable)
         {
-            using (var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, true))
+            try
             {
-                string exePath = $"\"{Application.ExecutablePath}\" --silent";
+                using (var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, true) ??
+                                   Registry.CurrentUser.CreateSubKey(RunKeyPath))
+                {
+                    if (key == null)
+                    {
+                        Debug.WriteLine("Failed to access or create the Run registry key.");
+                        return;
+                    }
 
-                if (enable)
-                    key.SetValue(AppName, exePath);
-                else
-                    key.DeleteValue(AppName, false);
+                    string exePath = $"\"{Application.ExecutablePath}\" --silent";
+
+                    if (enable)
+                        key.SetValue(AppName, exePath);
+                    else
+                        key.DeleteValue(AppName, false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error setting Run on startup: {ex.Message}");
             }
         }
 
         private bool IsRunOnStartupEnabled()
         {
-            using (var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, false))
+            try
             {
-                string exePath = $"\"{Application.ExecutablePath}\" --silent";
-                string value = key?.GetValue(AppName) as string;
-                return value == exePath;
+                using (var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, false) ??
+                                   Registry.CurrentUser.CreateSubKey(RunKeyPath))
+                {
+                    if (key == null)
+                    {
+                        Debug.WriteLine("Failed to access or create the Run registry key.");
+                        return false;
+                    }
+
+                    string exePath = $"\"{Application.ExecutablePath}\" --silent";
+                    string value = key.GetValue(AppName) as string;
+                    return value == exePath;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error checking Run on startup: {ex.Message}");
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary
- Safely create or access the Run registry key when toggling startup behavior
- Add exception handling and debug logging for registry operations

## Testing
- `dotnet build PowerCommander.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*