### PR TITLE
Centralize settings loading

### DIFF
--- a/PowerCommander/MainForm.cs
+++ b/PowerCommander/MainForm.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Text.Json;
 using System.Windows.Forms;
 
 namespace PowerCommander
@@ -56,7 +52,7 @@ namespace PowerCommander
         /// </summary>
         private void MainForm_Load(object sender, EventArgs e)
         {
-            settings = LoadSettings();
+            settings = SettingsLoader.Load();
 
             if (settings?.LoadService == true)
             {
@@ -87,45 +83,5 @@ namespace PowerCommander
 
         #endregion
 
-        #region Settings Loader
-
-        /// <summary>
-        /// Loads the app settings from settings.json or creates a default config if missing.
-        /// </summary>
-        /// <returns>A populated PowerCommanderSettings instance.</returns>
-        private PowerCommanderSettings LoadSettings()
-        {
-            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json");
-
-            var defaultSettings = new PowerCommanderSettings
-            {
-                LoadService = true,
-                ShutdownTimes = new List<string> { "19:53" }
-            };
-
-            if (!File.Exists(path))
-            {
-                string defaultJson = JsonSerializer.Serialize(defaultSettings, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(path, defaultJson);
-
-                return defaultSettings;
-            }
-
-            try
-            {
-                string json = File.ReadAllText(path);
-                return JsonSerializer.Deserialize<PowerCommanderSettings>(json, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                }) ?? defaultSettings;
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Failed to load settings: {ex.Message}", "Power Commander", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                return defaultSettings;
-            }
-        }
-
-        #endregion
     }
 }

--- a/PowerCommander/PowerCommander.csproj
+++ b/PowerCommander/PowerCommander.csproj
@@ -102,6 +102,7 @@
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
     <Compile Include="PowerCommanderSettings.cs" />
+    <Compile Include="SettingsLoader.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceForm.cs">

--- a/PowerCommander/PowerCommanderSettings.cs
+++ b/PowerCommander/PowerCommanderSettings.cs
@@ -2,8 +2,8 @@
 
 public class PowerCommanderSettings
 {
-    public bool LoadService { get; set; } = false;
-    public List<string> ShutdownTimes { get; set; }
+    public bool LoadService { get; set; } = true;
+    public List<string> ShutdownTimes { get; set; } = new List<string> { "21:00" };
     public bool ShowNextScheduledTime { get; set; } = true;
     public bool EnableExitOption { get; set; } = true;
     public bool EnableManualShutdown { get; set; } = true;

--- a/PowerCommander/ServiceForm.cs
+++ b/PowerCommander/ServiceForm.cs
@@ -1,11 +1,8 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Windows.Forms;
 
 namespace PowerCommander
@@ -42,7 +39,7 @@ namespace PowerCommander
             this.ShowInTaskbar = false;
             this.Visible = false;
 
-            settings = LoadSettings();
+            settings = SettingsLoader.Load();
             InitialiseTrayIcon();
             StartScheduleMonitor();
         }
@@ -199,12 +196,12 @@ namespace PowerCommander
         /// </summary>
         private void StartScheduleMonitor()
         {
-            settings = LoadSettings();
-
+            settings = SettingsLoader.Load();
+            
             scheduleChecker = new Timer { Interval = 60000 }; // Every 1 minute
             scheduleChecker.Tick += (s, e) =>
             {
-                var updatedSettings = LoadSettings();
+                var updatedSettings = SettingsLoader.Load();
                 var now = DateTime.Now;
 
                 bool shouldShutdown = updatedSettings.ShutdownTimes?.Any(t =>
@@ -228,39 +225,6 @@ namespace PowerCommander
             scheduleChecker.Start();
         }
 
-
-        #endregion
-
-        #region Settings Handling
-
-        /// <summary>
-        /// Loads shutdown schedule settings from a JSON file, or creates a default one.
-        /// </summary>
-        /// <returns>Populated settings object.</returns>
-        private PowerCommanderSettings LoadSettings()
-        {
-            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json");
-
-            if (!File.Exists(path))
-            {
-                var defaultSettings = new PowerCommanderSettings
-                {
-                    LoadService = true,
-                    ShutdownTimes = new List<string> { "21:00" }
-                };
-
-                string defaultJson = JsonSerializer.Serialize(defaultSettings, new JsonSerializerOptions { WriteIndented = true });
-                File.WriteAllText(path, defaultJson);
-
-                return defaultSettings;
-            }
-
-            string json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<PowerCommanderSettings>(json, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            });
-        }
 
         #endregion
 

--- a/PowerCommander/SettingsLoader.cs
+++ b/PowerCommander/SettingsLoader.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace PowerCommander
+{
+    public static class SettingsLoader
+    {
+        private static readonly string SettingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "settings.json");
+
+        public static PowerCommanderSettings Load()
+        {
+            var defaults = new PowerCommanderSettings();
+
+            try
+            {
+                if (!File.Exists(SettingsPath))
+                {
+                    Save(defaults);
+                    return defaults;
+                }
+
+                var json = File.ReadAllText(SettingsPath);
+                var settings = JsonSerializer.Deserialize<PowerCommanderSettings>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                }) ?? new PowerCommanderSettings();
+
+                if (settings.ShutdownTimes == null || settings.ShutdownTimes.Count == 0)
+                {
+                    settings.ShutdownTimes = defaults.ShutdownTimes;
+                }
+
+                return settings;
+            }
+            catch
+            {
+                return defaults;
+            }
+        }
+
+        private static void Save(PowerCommanderSettings settings)
+        {
+            var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(SettingsPath, json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SettingsLoader` to load `settings.json`, apply defaults and create file when missing
- define defaults in `PowerCommanderSettings` and remove form-specific loaders
- update forms to consume `SettingsLoader`