### PR TITLE
Wrap PowerCommanderSettings in namespace and fix shutdown list initialization

### DIFF
--- a/PowerCommander/MainForm.cs
+++ b/PowerCommander/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using PowerCommanderSettings = PowerCommander.PowerCommanderSettings;
 
 namespace PowerCommander
 {

--- a/PowerCommander/PowerCommanderSettings.cs
+++ b/PowerCommander/PowerCommanderSettings.cs
@@ -1,11 +1,15 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
-public class PowerCommanderSettings
+namespace PowerCommander
 {
-    public bool LoadService { get; set; } = true;
-    public List<string> ShutdownTimes { get; set; } = new List<string> { "21:00" };
-    public bool ShowNextScheduledTime { get; set; } = true;
-    public bool EnableExitOption { get; set; } = true;
-    public bool EnableManualShutdown { get; set; } = true;
-    public bool EnableStartupToggle { get; set; } = true;
+    public class PowerCommanderSettings
+    {
+        public bool LoadService { get; set; } = true;
+        public List<string> ShutdownTimes { get; set; } = new List<string>();
+        public bool ShowNextScheduledTime { get; set; } = true;
+        public bool EnableExitOption { get; set; } = true;
+        public bool EnableManualShutdown { get; set; } = true;
+        public bool EnableStartupToggle { get; set; } = true;
+    }
 }
+

--- a/PowerCommander/ServiceForm.cs
+++ b/PowerCommander/ServiceForm.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using PowerCommanderSettings = PowerCommander.PowerCommanderSettings;
 
 namespace PowerCommander
 {

--- a/PowerCommander/SettingsLoader.cs
+++ b/PowerCommander/SettingsLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Json;
+using PowerCommanderSettings = PowerCommander.PowerCommanderSettings;
 
 namespace PowerCommander
 {


### PR DESCRIPTION
## Summary
- wrap PowerCommanderSettings in PowerCommander namespace
- initialize ShutdownTimes with empty list to prevent null references
- update form and loader files to reference the namespaced settings class