### PR TITLE
Handle next-day shutdown schedule

### DIFF
--- a/PowerCommander/ServiceForm.cs
+++ b/PowerCommander/ServiceForm.cs
@@ -185,13 +185,18 @@ namespace PowerCommander
 
             var now = DateTime.Now;
 
-            var upcomingTimes = settings.ShutdownTimes
-                .Select(t => TimeSpan.TryParse(t, out var ts) ? DateTime.Today.Add(ts) : DateTime.MaxValue)
-                .Where(dt => dt > now)
+            var nextTime = settings.ShutdownTimes
+                .Select(t => TimeSpan.TryParse(t, out var ts) ? DateTime.Today.Add(ts) : (DateTime?)null)
+                .Where(dt => dt.HasValue)
+                .Select(dt => dt.Value <= now ? dt.Value.AddDays(1) : dt.Value)
                 .OrderBy(dt => dt)
-                .ToList();
+                .FirstOrDefault();
 
-            return upcomingTimes.Count == 0 ? "None today" : upcomingTimes.First().ToString("HH:mm");
+            if (nextTime == default)
+                return "None";
+
+            var timeString = nextTime.ToString("HH:mm");
+            return nextTime.Date > DateTime.Today ? $"{timeString} tomorrow" : timeString;
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- Extend shutdown scheduling to roll over to next day when all configured times have passed.
- Display "tomorrow" for shutdown times that occur on the next day.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b163b533dc832bbac008f9e6a2f3a1